### PR TITLE
Add detail to README instructions, remove f-string for wider 3.x use

### DIFF
--- a/Get Flashcards.ipynb
+++ b/Get Flashcards.ipynb
@@ -26,8 +26,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "auth = tweepy.OAuthHandler('8GeJhB571lnVAwVDqShipFMqF', 'v33EaJnnDBAJCdzCioHCECbkIZm0MIhc3vxkNC400lIiUAnevV') #Fill these in\n",
-    "auth.set_access_token('1917957140-SW7ERvT5hEgHaIrH83EhcQhg8PnXCHAb9mFA4XR', '26OpSyuGLyySQl47BCti8aXZyijNyGjAv0tfS6O79LXKi')  #Fill these in\n",
+    "auth = tweepy.OAuthHandler(consumer_key, consumer_secret) #Fill these in\n",
+    "auth.set_access_token(access_token, access_token_secret)  #Fill these in\n",
     "\n",
     "api = tweepy.API(auth)\n",
     "\n",

--- a/Get Flashcards.ipynb
+++ b/Get Flashcards.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,12 +22,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
-    "auth = tweepy.OAuthHandler(consumer_key, consumer_secret) #Fill these in\n",
-    "auth.set_access_token(access_token, access_token_secret)  #Fill these in\n",
+    "auth = tweepy.OAuthHandler('8GeJhB571lnVAwVDqShipFMqF', 'v33EaJnnDBAJCdzCioHCECbkIZm0MIhc3vxkNC400lIiUAnevV') #Fill these in\n",
+    "auth.set_access_token('1917957140-SW7ERvT5hEgHaIrH83EhcQhg8PnXCHAb9mFA4XR', '26OpSyuGLyySQl47BCti8aXZyijNyGjAv0tfS6O79LXKi')  #Fill these in\n",
     "\n",
     "api = tweepy.API(auth)\n",
     "\n",
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,14 +99,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
     "os.makedirs('ml-cards', exist_ok=True) #make a directory to store the photos in\n",
     "\n",
-    "for text, url in media_files.items():\n",
-    "    wget.download(url, out = f'ml-cards/{text}.png') #get the photos!"
+    "for title, url in media_files.items():\n",
+    "   wget.download(url, out = \"ml-cards/{}.png\".format(title)) #get the photos!"
    ]
   },
   {
@@ -140,7 +140,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,

--- a/README.md
+++ b/README.md
@@ -1,12 +1,63 @@
 # GetCards
 
-Data scientist [Chris Albon](https://chrisalbon.com/) has been posting pictures of his machine learning flash cards [on Twitter](https://twitter.com/chrisalbon?lang=en).  Here is how to automatically download them using python.
+Data scientist [Chris Albon](https://chrisalbon.com/) has been posting pictures of his machine learning flash cards [on Twitter](https://twitter.com/chrisalbon?lang=en). This repo uses a [Jupyter](http://jupyter.org/) notebook to download them for convenient viewing.
 
 
-### For OSX/Linux
-In case you do not have the modules used in the notebook nor jupyter installed, simply type 
+## OSX/Linux
+
+To use this repo, you will:
+
+* Install [Jupyter](http://jupyter.org/) and required modules
+* Create a Twitter app to provide programmatic access to Twitter
+* Run the Jupyter notebook
+* View the png images it downloads to the repo's `ml-cards` directory.
+
+
+### Install Jupyter
+
+Run this command to install Jupyter and required modules:
+
 * `pip install -r module_list.txt`
- 
-into terminal. Then run the notebook from terminal with
+
+### Create your Twitter app
+
+This repo uses [tweepy](https://github.com/tweepy/tweepy) to interact with Twitter. To use it, you will create a new Twitter app and insert those credentials into `Get Flashcards.ipnyb`.
+
+1. Log into twitter
+1. Browse to [https://apps.twitter.com/](https://apps.twitter.com/)
+1. Click the `Create New App` button and define your new app. Here are some example values:
+    * **Name**: `Get Flashcards - <your name>`
+    * **Description**: `Chris Albon ML Flashcard puller`
+    * **Website**: `http://www.not-used.com`
+    * **Callback URLs**: `` <= blank
+1. Check the **Developer Agreement** and click the `Create your Twitter application` button.
+1. In the application details page, Select the "Keys and Access Tokens" tab.
+1. Under "Your Access Token", click the `Create my access token` button.
+
+### Insert your credentials
+
+Open `Get Flashcards.ipynb` and locate these two lines:
+
+```
+    "auth = tweepy.OAuthHandler(consumer_key, consumer_secret) #Fill these in\n",
+    "auth.set_access_token(access_token, access_token_secret)  #Fill these in\n",
+```
+
+Replace the `consumer_key`, `consumer_secret`, `access_token`, and `access_token_secret` with single-quoted values from your application settings created in the previous step.
+
+See the [tweepy tutorial](http://docs.tweepy.org/en/v3.5.0/auth_tutorial.html) for more information, if needed.
+
+### Run the Jupyter notebook
+
+Run the Jupyter notebook from a shell in the repo root directory
 
 * `jupyter notebook Get\ Flashcards.ipynb`
+
+Jupyter will open a browser page, execute the code, placing all ML flashcards in a `ml-cards` local directory.
+
+You can enter `CTRL+C` twice to stop jupyter from the command line.
+
+### View the cards
+
+All cards are stored in a local `ml-cards` directory.
+


### PR DESCRIPTION
f-strings were not added until python 3.6. Reverted to older style
string formatting to allow use by older 3.x python versions and
simplify use for less knowledgeable python users.